### PR TITLE
Test branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,6 @@ Based on the fine work of [mikeastock's pipefitter](https://github.com/mikeastoc
 ## Limitations
 - Right now if any commits in a push contain "[run circle]" all commits will run circle.
 - If you push right after a "[run circle]" commit, circle will be cancelled.
+
+## Local Testing
+I use [ngrok](https://ngrok.com/) and the command `ngrok http 9292`

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Based on the fine work of [mikeastock's pipefitter](https://github.com/mikeastoc
 - `SIDEKIQ_USERNAME` & `SIDEKIQ_PASSWORD` for sidekiq authentication
 - `CIRCLECI_TOKEN` for circle access
 - `SECRET_TOKEN` set this as the secret in the Github Webhook for authentication (optional)
+- `TEST_BRANCH` set this as a branch name and Circle Reaper will only run on that branch (optional)
 
 ## How to use
 ### Setup

--- a/lib/circle_reaper/circle_worker.rb
+++ b/lib/circle_reaper/circle_worker.rb
@@ -6,8 +6,7 @@ module CircleReaper
 
     def perform(json)
       self.payload = HashWithIndifferentAccess.new(json)
-
-      return if branch == "master"
+      return if branch == "master" || (ENV["TEST_BRANCH"] && ENV["TEST_BRANCH"] == branch)
 
       if builds.count > 1
         builds.drop(1).each do |build|

--- a/lib/circle_reaper/circle_worker.rb
+++ b/lib/circle_reaper/circle_worker.rb
@@ -6,7 +6,7 @@ module CircleReaper
 
     def perform(json)
       self.payload = HashWithIndifferentAccess.new(json)
-      return if branch == "master" || (ENV["TEST_BRANCH"] && ENV["TEST_BRANCH"] == branch)
+      return if disallow_branch?(branch)
 
       if builds.count > 1
         builds.drop(1).each do |build|
@@ -33,6 +33,10 @@ module CircleReaper
       CircleCi::Project.recent_builds_branch(owner, repo, branch).body
     end
 
+    def disallow_branch?(branch)
+      branch == "master" || (test_branch && branch != test_branch)
+    end
+
     def owner
       payload.fetch(:repository).fetch(:owner).fetch(:name)
     end
@@ -43,6 +47,10 @@ module CircleReaper
 
     def branch
       payload.fetch(:ref).split("/").last
+    end
+
+    def test_branch
+      ENV["TEST_BRANCH"]
     end
   end
 end


### PR DESCRIPTION
This allows an optional branch to be set as the only branch that Circle Reaper runs on.
