### PR TITLE
Write tests for authentication

### DIFF
--- a/spec/circle_reaper/app_spec.rb
+++ b/spec/circle_reaper/app_spec.rb
@@ -32,5 +32,55 @@ RSpec.describe CircleReaper::App do
         post "/payload", body
       end
     end
+
+    context "secret token is set" do
+      it "verifies signature of the request" do
+        body = File.read("spec/fixtures/webhook_body.json")
+
+        secret_token = "some-token"
+        ENV["SECRET_TOKEN"] = secret_token
+
+        digest = OpenSSL::HMAC.hexdigest(
+          OpenSSL::Digest.new("sha1"),
+          secret_token,
+          body
+        )
+
+        allow(CircleReaper::CircleWorker).to receive(:perform_in)
+
+        post "/payload", body, { "HTTP_X_HUB_SIGNATURE" => "sha1=#{digest}" }
+
+        expect(last_response).to be_ok
+
+        ENV["SECRET_TOKEN"] = nil
+      end
+
+      it "returns 500 with 'Signatures didn't match' when verification fails" do
+        body = File.read("spec/fixtures/webhook_body.json")
+
+        secret_token = "some-token"
+        ENV["SECRET_TOKEN"] = secret_token
+
+        allow(CircleReaper::CircleWorker).to receive(:perform_in)
+
+        post "/payload", body, { "HTTP_X_HUB_SIGNATURE" => "sha1=fake-digest" }
+
+        expect(last_response).to be_server_error
+
+        ENV["SECRET_TOKEN"] = nil
+      end
+    end
+
+    context "secret token is not set" do
+      it "no verification of request" do
+        body = File.read("spec/fixtures/webhook_body.json")
+
+        allow(CircleReaper::CircleWorker).to receive(:perform_in)
+
+        post "/payload", body
+
+        expect(last_response).to be_ok
+      end
+    end
   end
 end


### PR DESCRIPTION
Also we no longer need to rewind the request body as we store the body
in a local var and use it for verification
